### PR TITLE
Implement a basic thread pool to be used by all the coroutines

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -14,13 +14,15 @@ target_sources(shared
     "include/http_request.h"
     "include/http_response.h"
     "include/snowflake.h"
-    "include/wsa.h" 
+    "include/thread_pool.h"
+    "include/wsa.h"
 
     "src/connection.cpp"
     "src/snowflake.cpp"
     "src/http.cpp"
-    "src/http_request.cpp" 
+    "src/http_request.cpp"
     "src/http_response.cpp"
+    "src/thread_pool.cpp"
     "src/wsa.cpp"
 )
 

--- a/shared/include/thread_pool.h
+++ b/shared/include/thread_pool.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+namespace pine
+{
+  /// @brief Thread pool for executing tasks.
+  /// @details The thread pool is created with a fixed number of threads that
+  /// are used to execute tasks asynchronously. The tasks are enqueued and
+  /// executed by the threads in the pool.
+  class thread_pool
+  {
+  public:
+    /// @brief Construct a thread pool with a fixed number of threads.
+    /// @param num_threads The number of threads in the pool.
+    explicit thread_pool(size_t num_threads = std::jthread::hardware_concurrency());
+
+    /// @brief Destroy the thread pool.
+    ~thread_pool();
+
+    /// @brief Enqueue a task to be executed by the thread pool.
+    /// @tparam task_type The type of the task to enqueue.
+    /// @param task The task to enqueue.
+    template <typename task_type>
+    inline void enqueue(task_type&& task)
+    {
+      std::unique_lock lock(this->queue_mutex);
+      this->tasks.emplace(std::forward<task_type>(task));
+      this->condition.notify_one();
+    }
+
+  private:
+    /// @brief Start the thread pool.
+    /// @param num_threads The number of threads in the pool.
+    void start_pool(size_t num_threads);
+
+    /// @brief Stop the thread pool.
+    void stop_pool();
+
+    std::vector<std::jthread> threads;
+    std::queue<std::function<void()>> tasks;
+    std::mutex queue_mutex;
+    std::condition_variable condition;
+    bool stop = false;
+  };
+}

--- a/shared/src/thread_pool.cpp
+++ b/shared/src/thread_pool.cpp
@@ -1,0 +1,54 @@
+#include <functional>
+#include <mutex>
+#include <type_traits>
+#include <vector>
+#include "thread_pool.h"
+
+namespace pine
+{
+  thread_pool::thread_pool(size_t num_threads)
+  {
+    this->start_pool(num_threads);
+  }
+
+  thread_pool::~thread_pool()
+  {
+    this->stop_pool();
+    this->condition.notify_all();
+    for (auto& thread : this->threads)
+      thread.join();
+  }
+
+  void thread_pool::start_pool(size_t num_threads)
+  {
+    for (size_t i = 0; i < num_threads; i++)
+    {
+      this->threads.emplace_back(
+        [this]
+        {
+          while (true)
+          {
+            std::function<void()> task;
+            {
+              std::unique_lock lock(this->queue_mutex);
+              this->condition.wait(lock, [this]
+                                   {
+                                     return this->stop || !this->tasks.empty();
+                                   });
+              if (this->stop && this->tasks.empty())
+                return;
+              task = std::move(this->tasks.front());
+              this->tasks.pop();
+            }
+            task();
+          }
+        });
+    }
+  }
+
+  void thread_pool::stop_pool()
+  {
+    std::unique_lock lock(this->queue_mutex);
+    this->stop = true;
+  }
+}


### PR DESCRIPTION
#### PR Classification
New feature: Added a thread pool module to manage asynchronous task execution.

#### PR Summary
Introduced a `thread_pool` class within the `pine` namespace to manage a pool of threads for asynchronous task execution.
- `CMakeLists.txt`: Included `include/thread_pool.h` and `src/thread_pool.cpp`.
- `thread_pool.h`: Defined the `thread_pool` class with methods to enqueue tasks, start, and stop the pool.
- `thread_pool.cpp`: Implemented the `thread_pool` methods, including thread initialization and management.

closes: #6 