### PR TITLE
Use pine error type instead of std::error_code and std::system_error

### DIFF
--- a/client/include/client_connection.h
+++ b/client/include/client_connection.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <error.h>
 #include <string>
 #include <thread>
 #include "connection.h"
@@ -30,16 +31,16 @@ namespace pine
 
     /// @brief Start listening for messages from the server.
     /// @return An asynchronous task completed when the connection has been closed.
-    async_operation<void, std::error_code> listen() const;
+    async_operation<void> listen() const;
 
     /// @brief Receive an HTTP response from the server.
     /// @return An asynchronous task completed when the response has been received.
-    async_operation<http_response, std::error_code> receive_response() const;
+    async_operation<http_response> receive_response() const;
 
     /// @brief Send an HTTP request to the server.
     /// @param request The request to send.
     /// @return An asynchronous task completed when the request has been sent.
-    async_operation<void, std::error_code> send_request(http_request const& request) const;
+    async_operation<void> send_request(http_request const& request) const;
 
   private:
     std::jthread client_thread;

--- a/client/src/client_connection.cpp
+++ b/client/src/client_connection.cpp
@@ -64,6 +64,6 @@ namespace pine
     if (!send_result)
       co_return send_result.error();
 
-    co_return {};
+    co_return error(error_code::success);
   }
 }

--- a/client/src/client_connection.cpp
+++ b/client/src/client_connection.cpp
@@ -1,5 +1,6 @@
 #include <coroutine.h>
 #include <cstdint>
+#include <error.h>
 #include <http_request.h>
 #include <http_response.h>
 #include <string>
@@ -30,7 +31,7 @@ namespace pine
     this->close();
   }
 
-  async_operation<void, std::error_code>
+  async_operation<void>
     client_connection::listen() const
   {
     while (true)
@@ -41,7 +42,7 @@ namespace pine
     }
   }
 
-  async_operation<http_response, std::error_code>
+  async_operation<http_response>
     client_connection::receive_response() const
   {
     const auto& received_message_result = co_await this->receive_raw_message();
@@ -54,7 +55,7 @@ namespace pine
     co_return response;
   }
 
-  async_operation<void, std::error_code>
+  async_operation<void>
     client_connection::send_request(http_request const& request) const
   {
     const auto& request_string = request.to_string();

--- a/server/include/server.h
+++ b/server/include/server.h
@@ -2,6 +2,7 @@
 
 #include <coroutine.h>
 #include <cstdint>
+#include <error.h>
 #include <expected.h>
 #include <functional>
 #include <memory>
@@ -24,7 +25,7 @@ namespace pine
     explicit server(const char* port = "80");
 
     /// @brief Start listening for connections.
-    std::expected<void, std::error_code> start();
+    std::expected<void, pine::error> start();
 
     /// @brief Stop listening for connections.
     void stop();
@@ -33,7 +34,7 @@ namespace pine
     /// @param client_id Id of the client to disconnect.
     /// @return An asynchronous task completed when the client has been
     /// disconnected.
-    async_operation<void, std::error_code> disconnect_client(
+    async_operation<void> disconnect_client(
       uint64_t const& client_id);
 
   private:
@@ -42,7 +43,7 @@ namespace pine
     /// connection for each client.
     /// @return An asynchronous task completed when the server has stopped
     /// listening.
-    std::expected<void, std::error_code> accept_clients();
+    std::expected<void, pine::error> accept_clients();
 
     std::mutex delete_clients_mutex;
     std::mutex mutate_clients_mutex;
@@ -67,7 +68,7 @@ namespace pine
     /// @return A reference to this server.
     server&
       on_connection_attempt(
-      std::function<async_operation<void, std::error_code>(server&,
+      std::function<async_operation<void>(server&,
       std::shared_ptr<server_connection> const&)> const& callback
       );
 
@@ -77,7 +78,7 @@ namespace pine
     /// @return A reference to this server.
     server&
       on_connection_failed(
-      std::function < async_operation<void, std::error_code>(
+      std::function < async_operation<void>(
       server&,
       std::shared_ptr<server_connection> const&)> const& callback
       );
@@ -87,7 +88,7 @@ namespace pine
     /// connects to the server.
     /// @return A reference to this server.
     server&
-      on_connection(std::function < async_operation<void, std::error_code>(
+      on_connection(std::function < async_operation<void>(
       server&,
       std::shared_ptr<server_connection> const&)> const& callback
       );
@@ -97,27 +98,27 @@ namespace pine
     /// to accept connections.
     /// @return A reference to this server.
     server&
-      on_ready(std::function < async_operation<void, std::error_code>(
+      on_ready(std::function < async_operation<void>(
       server&)> const& callback
     );
 
   private:
-    std::vector<std::function<async_operation<void, std::error_code>(
+    std::vector<std::function<async_operation<void>(
       server&,
       std::shared_ptr<server_connection> const&)>
     > on_connection_attemps_callbacks;
 
-    std::vector<std::function<async_operation<void, std::error_code>(
+    std::vector<std::function<async_operation<void>(
       server&,
       std::shared_ptr<server_connection> const&)>
     > on_connection_failed_callbacks;
 
-    std::vector<std::function<async_operation<void, std::error_code>(
+    std::vector<std::function<async_operation<void>(
       server&,
       std::shared_ptr<server_connection> const&)>
     > on_connection_callbacks;
 
-    std::vector < std::function < async_operation<void, std::error_code>(
+    std::vector < std::function < async_operation<void>(
       server&)>
     > on_ready_callbacks;
   };

--- a/server/include/server_connection.h
+++ b/server/include/server_connection.h
@@ -21,16 +21,16 @@ namespace pine
 
     /// @brief Receive an HTTP request.
     /// @return An asynchronous task completed when the request has been received.
-    async_operation<http_request, std::error_code> receive_request() const;
+    async_operation<http_request> receive_request() const;
 
     /// @brief Send an HTTP response.
     /// @param response The response to send.
     /// @return An asynchronous task completed when the response has been sent.
-    async_operation<void, std::error_code> send_response(http_response const& response) const;
+    async_operation<void> send_response(http_response const& response) const;
 
     /// @brief Start listening for messages from the client.
     /// @return An asynchronous task completed when the connection has been closed.
-    async_operation<void, std::error_code> start();
+    async_operation<void> start();
 
   private:
     /// @brief Whether the connection is connected.

--- a/server/src/server_connection.cpp
+++ b/server/src/server_connection.cpp
@@ -13,7 +13,7 @@ namespace pine
   server_connection::server_connection(SOCKET socket) : connection(socket)
   {}
 
-  async_operation<http_request, std::error_code>
+  async_operation<http_request>
     pine::server_connection::receive_request() const
   {
     const auto& receive_message_result = co_await this->receive_raw_message();
@@ -29,7 +29,7 @@ namespace pine
     co_return request_result.value();
   }
 
-  async_operation<void, std::error_code>
+  async_operation<void>
     server_connection::send_response(http_response const& response) const
   {
     const std::string& response_string = response.to_string();
@@ -39,10 +39,10 @@ namespace pine
     if (!send_message_result)
       co_return send_message_result.error();
 
-    co_return make_error_code(error::success);
+    co_return error(error_code::success);
   }
 
-  async_operation<void, std::error_code>
+  async_operation<void>
     server_connection::start()
   {
     this->is_connected = true;
@@ -58,6 +58,6 @@ namespace pine
     }
 
     this->is_connected = false;
-    co_return make_error_code(error::success);
+    co_return error(error_code::success);
   }
 }

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(shared
     "include/wsa.h"
 
     "src/connection.cpp"
+    "src/error.cpp"
     "src/http.cpp"
     "src/http_request.cpp"
     "src/http_response.cpp"

--- a/shared/include/connection.h
+++ b/shared/include/connection.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 #include "coroutine.h"
+#include "error.h"
 #include "snowflake.h"
 
 #ifdef _WIN32
@@ -24,13 +25,13 @@ namespace pine
 
     /// @brief Receive a raw message to the connection.
     /// @return An asynchronous operation that returns the received bytes.
-    async_operation<std::string, std::error_code>
+    async_operation<std::string>
       receive_raw_message() const;
 
     /// @brief Send a raw message to the connection.
     /// @param raw_message Message to send.
     /// @return An asynchronous task completed when the message has been sent.
-    async_operation<void, std::error_code>
+    async_operation<void>
       send_raw_message(std::string_view raw_message) const;
 
     /// @brief Close the connection.

--- a/shared/include/error.h
+++ b/shared/include/error.h
@@ -17,6 +17,7 @@ namespace pine
     connection_closed,
   #ifdef _WIN32
     winsock_error,
+    getaddrinfo_error,
   #endif // _WIN32
     coroutine_cancelled,
   };

--- a/shared/include/error.h
+++ b/shared/include/error.h
@@ -14,6 +14,11 @@ namespace pine
     parse_error_body,
     parse_error_status,
     client_not_found,
+    connection_closed,
+  #ifdef _WIN32
+    winsock_error,
+  #endif // _WIN32
+    coroutine_cancelled,
   };
 
   class error

--- a/shared/include/error.h
+++ b/shared/include/error.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <string>
-#include <system_error>
 
 namespace pine
 {
-  enum class error
+  enum class error_code
   {
     success,
     parse_error_method,
@@ -17,41 +16,16 @@ namespace pine
     client_not_found,
   };
 
-  class error_category : public std::error_category
+  class error
   {
   public:
-    inline const char* name() const noexcept override { return "pine"; }
+    error(error_code code);
+    error(error_code code, const std::string& message);
+    error_code code() const;
+    const std::string& message() const;
 
-    inline std::string message(int code) const override
-    {
-      using enum error;
-
-      switch (static_cast<error>(code))
-      {
-      case success:
-        return "Success";
-      case parse_error_method:
-        return "Parse error: method";
-      case parse_error_uri:
-        return "Parse error: URI";
-      case parse_error_version:
-        return "Parse error: version";
-      case parse_error_headers:
-        return "Parse error: headers";
-      case parse_error_body:
-        return "Parse error: body";
-      case parse_error_status:
-        return "Parse error: status";
-      default:
-        return "Unknown";
-      }
-    }
+  private:
+    error_code code_;
+    std::string message_;
   };
-
-  inline const error_category global_error_category;
-
-  inline std::error_code make_error_code(error e) noexcept
-  {
-    return std::error_code(static_cast<int>(e), global_error_category);
-  }
 }

--- a/shared/include/http.h
+++ b/shared/include/http.h
@@ -3,7 +3,7 @@
 #include <map>
 #include <string>
 #include <string_view>
-#include <system_error>
+#include "error.h"
 #include "expected.h"
 
 namespace pine
@@ -63,49 +63,49 @@ namespace pine
     /// @param request The HTTP request.
     /// @param offset The offset in the request where the body starts.
     /// @return The extracted body as a string.
-    std::expected<std::string, std::error_code>
+    std::expected<std::string, pine::error>
       try_get_body(std::string_view request, size_t& offset);
 
     /// @brief Tries to extract the headers from an HTTP request.
     /// @param request The HTTP request.
     /// @param offset The offset in the request where the headers start.
     /// @return The extracted headers as a map of key-value pairs.
-    std::expected<std::map<std::string, std::string>, std::error_code>
+    std::expected<std::map<std::string, std::string>, pine::error>
       try_get_headers(const std::string& request, size_t& offset);
 
     /// @brief Tries to extract a single header from an HTTP request.
     /// @param request The HTTP request.
     /// @param offset The offset in the request where the header starts.
     /// @return The extracted header as a pair of key and value.
-    std::expected<std::pair<std::string, std::string>, std::error_code>
+    std::expected<std::pair<std::string, std::string>, pine::error>
       try_get_header(std::string_view request, size_t& offset);
 
     /// @brief Tries to extract the HTTP method from an HTTP request.
     /// @param request The HTTP request.
     /// @param offset The offset in the request where the method starts.
     /// @return The extracted HTTP method.
-    std::expected<http_method, std::error_code>
+    std::expected<http_method, pine::error>
       try_get_method(std::string_view request, size_t& offset);
 
     /// @brief Tries to extract the HTTP status from an HTTP response.
     /// @param response The HTTP response.
     /// @param offset The offset in the response where the status starts.
     /// @return The extracted HTTP status.
-    std::expected<http_status, std::error_code>
+    std::expected<http_status, pine::error>
       try_get_status(std::string_view response, size_t& offset);
 
     /// @brief Tries to extract the URI from an HTTP request.
     /// @param request The HTTP request.
     /// @param offset The offset in the request where the URI starts.
     /// @return The extracted URI as a string.
-    std::expected<std::string, std::error_code>
+    std::expected<std::string, pine::error>
       try_get_uri(std::string_view request, size_t& offset);
 
     /// @brief Tries to extract the HTTP version from an HTTP request.
     /// @param request The HTTP request.
     /// @param offset The offset in the request where the version starts.
     /// @return The extracted HTTP version.
-    std::expected<http_version, std::error_code>
+    std::expected<http_version, pine::error>
       try_get_version(std::string_view request, size_t& offset);
   }
 }

--- a/shared/include/http_request.h
+++ b/shared/include/http_request.h
@@ -3,9 +3,9 @@
 #include <unordered_map>
 #include <string>
 #include <string_view>
-#include <system_error>
 #include <type_traits>
 #include <utility>
+#include "error.h"
 #include "expected.h"
 #include "http.h"
 
@@ -35,7 +35,7 @@ namespace pine
     /// @param request The string representation of the request.
     /// @return An expected object containing the parsed HTTP request or an
     /// error code.
-    static std::expected<http_request, std::error_code>
+    static std::expected<http_request, pine::error>
       parse(const std::string& request);
 
     /// @brief Gets the body of the HTTP request.

--- a/shared/include/http_response.h
+++ b/shared/include/http_response.h
@@ -3,7 +3,7 @@
 #include <map>
 #include <string>
 #include <string_view>
-#include <system_error>
+#include "error.h"
 #include "expected.h"
 #include "http.h"
 
@@ -19,7 +19,7 @@ namespace pine
     /// @brief Parses an HTTP response from a string.
     /// @param response The string representation of the HTTP response.
     /// @return An expected object containing the parsed HTTP response or an error code.
-    static std::expected<http_response, std::error_code>
+    static std::expected<http_response, pine::error>
       parse(const std::string& response);
 
     /// @brief Gets the body of the HTTP response.

--- a/shared/include/wsa.h
+++ b/shared/include/wsa.h
@@ -9,7 +9,7 @@ using SOCKET = unsigned long long;
 namespace pine
 {
   /// @brief Initialize the Windows Socket API.
-  std::expected<void, std::error_code> initialize_wsa();
+  std::expected<void, pine::error> initialize_wsa();
 
   /// @brief Cleanup the Windows Socket API.
   void cleanup_wsa();
@@ -19,26 +19,26 @@ namespace pine
   /// @param service The service name or port number.
   /// @return A pointer to the addrinfo structure containing the address
   /// information.
-  std::expected<addrinfo*, std::error_code>
+  std::expected<addrinfo*, pine::error>
     get_address_info(const char* node,
                      const char* service);
 
   /// @brief Create a socket with the specified address information.
   /// @param address_info The address information for the socket.
   /// @return The created socket.
-  std::expected<SOCKET, std::error_code>
+  std::expected<SOCKET, pine::error>
     create_socket(const addrinfo* address_info);
 
   /// @brief Bind the socket to the specified address.
   /// @param socket The socket to bind.
   /// @param address_info The address information for the socket.
-  std::expected<void, std::error_code>
+  std::expected<void, pine::error>
     bind_socket(SOCKET socket, const addrinfo* address_info);
 
   /// @brief Listen for incoming connections on the socket.
   /// @param socket The socket to listen on.
   /// @param backlog The maximum length of the queue of pending connections.
-  std::expected<void, std::error_code>
+  std::expected<void, pine::error>
     listen_socket(SOCKET socket, int backlog);
 
   /// @brief Accept an incoming connection on the socket.
@@ -46,14 +46,14 @@ namespace pine
   /// @param address_info The address information for the socket.
   /// @param ec An error code to be set if an error occurs.
   /// @return The accepted socket.
-  std::expected<SOCKET, std::error_code>
+  std::expected<SOCKET, pine::error>
     accept_socket(SOCKET socket, const addrinfo* address_info);
 
   /// @brief Connect the socket to the specified address.
   /// @param socket The socket to connect.
   /// @param address_info The address information for the socket.
   /// @param ec An error code to be set if an error occurs.
-  std::expected<void, std::system_error>
+  std::expected<void, pine::error>
     connect_socket(SOCKET socket, const addrinfo* address_info);
 
   /// @brief Close the socket.

--- a/shared/src/connection.cpp
+++ b/shared/src/connection.cpp
@@ -33,7 +33,8 @@ namespace pine
 
       if (bytes_received == 0)
       {
-        co_return error(error_code::connection_closed);
+        co_return error(error_code::connection_closed,
+                        "The connection was closed by the remote host.");
       }
 
       if (bytes_received == SOCKET_ERROR)

--- a/shared/src/error.cpp
+++ b/shared/src/error.cpp
@@ -1,0 +1,24 @@
+#include <string>
+#include "error.h"
+
+namespace pine
+{
+  error::error(error_code code)
+    : code_(code)
+  {}
+
+  error::error(error_code code, const std::string& message)
+    : code_(code)
+    , message_(message)
+  {}
+
+  error_code error::code() const
+  {
+    return code_;
+  }
+
+  const std::string& error::message() const
+  {
+    return message_;
+  }
+}

--- a/shared/src/http_request.cpp
+++ b/shared/src/http_request.cpp
@@ -1,7 +1,7 @@
 #include <cstring>
 #include <map>
 #include <string>
-#include <system_error>
+#include "error.h"
 #include "expected.h"
 #include "http.h"
 #include "http_request.h"
@@ -16,7 +16,7 @@ namespace pine
     : method(method), uri(uri), version(version), headers(headers), body(body)
   {}
 
-  std::expected<http_request, std::error_code>
+  std::expected<http_request, pine::error>
     http_request::parse(const std::string& request)
   {
     http_request result;

--- a/shared/src/http_response.cpp
+++ b/shared/src/http_response.cpp
@@ -2,13 +2,13 @@
 #include <expected.h>
 #include <format>
 #include <string>
-#include <system_error>
+#include "error.h"
 #include "http.h"
 #include "http_response.h"
 
 namespace pine
 {
-  std::expected<http_response, std::error_code>
+  std::expected<http_response, pine::error>
     http_response::parse(const std::string& response)
   {
     http_response result{};

--- a/shared/src/wsa.cpp
+++ b/shared/src/wsa.cpp
@@ -1,23 +1,24 @@
 #define WIN32_LEAN_AND_MEAN
 
-#include <expected.h>
-#include <system_error>
-#include <Windows.h>
-#include <WinSock2.h>
-#include <ws2def.h>
 #include <WS2tcpip.h>
+#include <WinSock2.h>
+#include <Windows.h>
+#include <expected.h>
+#include <string>
+#include <ws2def.h>
+#include "error.h"
 #include "wsa.h"
 
 namespace pine
 {
-  std::expected<void, std::error_code> initialize_wsa()
+  std::expected<void, pine::error> initialize_wsa()
   {
     WSADATA wsa_data = { 0 };
     if (int result = WSAStartup(MAKEWORD(2, 2), &wsa_data);
         result != 0)
     {
-      return std::make_unexpected(
-        std::make_error_code(static_cast<std::errc>(result)));
+      return std::make_unexpected(error(error_code::winsock_error,
+                                        std::to_string(result)));
     }
 
     return {};
@@ -28,7 +29,7 @@ namespace pine
     WSACleanup();
   }
 
-  std::expected<addrinfo*, std::error_code>
+  std::expected<addrinfo*, pine::error>
     get_address_info(const char* node, const char* service)
   {
     addrinfo* result = nullptr;
@@ -40,14 +41,14 @@ namespace pine
     if (int error = getaddrinfo(node, service, &hints, &result);
         error != 0)
     {
-      return std::make_unexpected(
-        std::make_error_code(static_cast<std::errc>(error)));
+      return std::make_unexpected(pine::error(error_code::getaddrinfo_error,
+                                              std::to_string(error)));
     }
 
     return result;
   }
 
-  std::expected<SOCKET, std::error_code>
+  std::expected<SOCKET, pine::error>
     create_socket(const addrinfo* address_info)
   {
     SOCKET socket = ::socket(address_info->ai_family,
@@ -56,64 +57,65 @@ namespace pine
 
     if (socket == INVALID_SOCKET)
     {
-      return std::make_unexpected(
-        std::make_error_code(static_cast<std::errc>(WSAGetLastError())));
+      return std::make_unexpected(error(error_code::winsock_error,
+                                        std::to_string(WSAGetLastError())));
+
     }
 
     return socket;
   }
 
-  std::expected<void, std::error_code>
+  std::expected<void, pine::error>
     bind_socket(SOCKET socket, const addrinfo* address_info)
   {
     if (bind(socket,
-        address_info->ai_addr,
-        static_cast<int>(address_info->ai_addrlen))
+             address_info->ai_addr,
+             static_cast<int>(address_info->ai_addrlen))
         == SOCKET_ERROR)
     {
-      return std::make_unexpected(
-        std::make_error_code(static_cast<std::errc>(WSAGetLastError())));
+      return std::make_unexpected(error(error_code::winsock_error,
+                                        std::to_string(WSAGetLastError())));
     }
 
     return {};
   }
 
-  std::expected<void, std::error_code>
+  std::expected<void, pine::error>
     listen_socket(SOCKET socket, int backlog)
   {
     if (listen(socket, backlog) == SOCKET_ERROR)
     {
-      return std::make_unexpected(
-        std::make_error_code(static_cast<std::errc>(WSAGetLastError())));
+      return std::make_unexpected(error(error_code::winsock_error,
+                                        std::to_string(WSAGetLastError())));
     }
 
     return {};
   }
 
-  std::expected<SOCKET, std::error_code>
+  std::expected<SOCKET, pine::error>
     accept_socket(SOCKET socket, const addrinfo* address_info)
   {
     SOCKET accepted_socket = accept(socket, address_info->ai_addr, nullptr);
 
     if (accepted_socket == INVALID_SOCKET)
     {
-      return std::make_unexpected(
-        std::make_error_code(static_cast<std::errc>(WSAGetLastError())));
+      return std::make_unexpected(error(error_code::winsock_error,
+                                        std::to_string(WSAGetLastError())));
     }
 
     return accepted_socket;
   }
 
-  std::expected<void, std::system_error>
+  std::expected<void, pine::error>
     connect_socket(SOCKET socket, const addrinfo* address_info)
   {
     if (connect(socket,
-        address_info->ai_addr,
-        static_cast<int>(address_info->ai_addrlen))
+                address_info->ai_addr,
+                static_cast<int>(address_info->ai_addrlen))
         == SOCKET_ERROR)
     {
-      return std::make_unexpected(
-        std::system_error(WSAGetLastError(), std::system_category()));
+      return std::make_unexpected(error(error_code::winsock_error,
+                                        std::to_string(WSAGetLastError())));
     }
 
     return {};

--- a/tests/unit/http_request_tests.cpp
+++ b/tests/unit/http_request_tests.cpp
@@ -76,6 +76,6 @@ TEST(HttpRequestTests, ParseInvalidRequest)
   auto result = pine::http_request::parse(requestStr);
   ASSERT_FALSE(result.has_value());
 
-  std::error_code error = result.error();
-  EXPECT_EQ(pine::make_error_code(pine::error::parse_error_method), error);
+  pine::error error = result.error();
+  EXPECT_EQ(pine::error_code::parse_error_method, error.code());
 }


### PR DESCRIPTION
#### PR Classification
API change to introduce a custom error handling mechanism.

#### PR Summary
This PR refactors the error handling mechanism by introducing a custom `pine::error` class and `pine::error_code` enum, replacing `std::error_code` and `std::system_error`.
- `error.cpp`: Added to define the `pine::error` class with constructors and methods.
- `http.cpp`, `http_request.cpp`, `http_response.cpp`, `wsa.cpp`: Updated to use `pine::error` for error handling.
- `client_connection.cpp`, `server.cpp`, `server_connection.cpp`, `connection.cpp`: Modified to handle errors using `pine::error`.
- `CMakeLists.txt`: Updated to include the new `error.cpp` source file.

closes: #12 