### PR TITLE
Add support for handling multiple HTTP methods in route handling

### DIFF
--- a/examples/server_example.cpp
+++ b/examples/server_example.cpp
@@ -16,7 +16,18 @@ int main()
                    {
                      response.set_status(pine::http_status::ok);
                      response.set_body("Hello, world!");
+                   })
+    .set_methods({ pine::http_method::get, pine::http_method::head });
+
+  server.add_route("/",
+                   pine::http_method::post,
+                   [](const pine::http_request& request,
+                      pine::http_response& response)
+                   {
+                     response.set_status(pine::http_status::ok);
+                     response.set_body("Hello, post!");
                    });
+
 
   server.add_static_route("/public_directory", std::filesystem::current_path() / "public");
   server.add_static_route("/public_file", std::filesystem::current_path() / "public" / "about.html");

--- a/server/include/route.h
+++ b/server/include/route.h
@@ -19,13 +19,6 @@ namespace pine
           handler);
     ~route() = default;
 
-    constexpr const std::string& path() const { return path_; }
-    constexpr route& set_path(std::string&& path)
-    {
-      path_ = std::move(path);
-      return *this;
-    }
-
     void execute(const http_request& request,
                  http_response& response) override;
 
@@ -49,7 +42,6 @@ namespace pine
     }
 
   private:
-    std::string path_;
     std::function<void(const http_request&, http_response&)> handler_;
   };
 }

--- a/server/include/route.h
+++ b/server/include/route.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <functional>
+#include <http.h>
 #include <http_request.h>
 #include <http_response.h>
 #include <route_base.h>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 namespace pine
 {
@@ -17,6 +19,18 @@ namespace pine
           std::function<void(const http_request&,
                              http_response&)>&&
           handler);
+    route(std::string&& path,
+          http_method method,
+          std::function<void(const http_request&,
+                             http_response&)>&&
+          handler);
+
+    route(std::string&& path,
+          std::vector<http_method>&& methods,
+          std::function<void(const http_request&,
+                             http_response&)>&&
+          handler);
+
     ~route() = default;
 
     void execute(const http_request& request,

--- a/server/include/route_base.h
+++ b/server/include/route_base.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <http.h>
 #include <http_request.h>
 #include <http_response.h>
 #include <string>
+#include <type_traits>
+#include <vector>
 
 namespace pine
 {
@@ -20,7 +23,43 @@ namespace pine
     virtual bool matches(const std::string& path) const = 0;
 
     constexpr const std::string& path() const { return path_; }
+
+  #pragma region Methods
+    constexpr const std::vector<http_method>& methods() const
+    {
+      return methods_;
+    }
+
+    constexpr route_base& set_methods(std::vector<http_method>&& methods)
+    {
+      methods_ = std::move(methods);
+      return *this;
+    }
+
+    constexpr route_base& set_method(http_method method)
+    {
+      methods_.clear();
+      methods_.push_back(method);
+      return *this;
+    }
+
+    constexpr route_base& add_method(http_method method)
+    {
+      methods_.push_back(method);
+      return *this;
+    }
+
+    constexpr route_base& add_methods(std::vector<http_method>&& methods)
+    {
+      methods_.insert(methods_.end(),
+                      std::make_move_iterator(methods.begin()),
+                      std::make_move_iterator(methods.end()));
+      return *this;
+    }
+  #pragma endregion
+
   protected:
+    std::vector<http_method> methods_ = { http_method::get };
     std::string path_;
   };
 }

--- a/server/include/route_base.h
+++ b/server/include/route_base.h
@@ -9,10 +9,18 @@ namespace pine
   class route_base
   {
   public:
+    route_base() = delete;
+    constexpr route_base(std::string&& path)
+      : path_(std::forward<std::string>(path))
+    {}
+
     virtual ~route_base() = default;
     virtual void execute(const http_request& request,
                          http_response& response) = 0;
-    virtual const std::string& path() const = 0;
     virtual bool matches(const std::string& path) const = 0;
+
+    constexpr const std::string& path() const { return path_; }
+  protected:
+    std::string path_;
   };
 }

--- a/server/include/server.h
+++ b/server/include/server.h
@@ -5,20 +5,21 @@
 #include <cstdint>
 #include <error.h>
 #include <expected.h>
+#include <filesystem>
 #include <functional>
+#include <http.h>
 #include <http_request.h>
 #include <http_response.h>
 #include <memory>
 #include <mutex>
-#include <route_base.h>
 #include <route.h>
+#include <route_base.h>
 #include <static_route.h>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
 #include <ws2def.h>
-#include <filesystem>
 
 namespace pine
 {
@@ -44,18 +45,43 @@ namespace pine
     async_operation<void> disconnect_client(
       uint64_t const& client_id);
 
-    /// @brief Add a route to the server.
+    /// @brief Add a route to the server. The route will be triggered when the
+    /// server receives a GET request to the specified path.
     /// @param path The HTTP path to match in order to call the handler.
     /// @param handler The function to call when the route is requested.
     /// The second parameter of the handler represents the response to send
     /// to the client.
     /// @return A reference to the created route.
     route& add_route(std::string&& path,
-                            std::function<void(const http_request&,
-                                               http_response&)>&& handler);
+                     std::function<void(const http_request&,
+                                        http_response&)>&& handler);
+    
+    /// @brief Add a route to the server.
+    /// @param path The HTTP path to match in order to call the handler.
+    /// @param method The HTTP method to match in order to call the handler.
+    /// @param handler The function to call when the route is requested.
+    /// The second parameter of the handler represents the response to send
+    /// to the client.
+    /// @return A reference to the created route.
+    route& add_route(std::string&& path,
+                     pine::http_method method,
+                     std::function<void(const http_request&,
+                                        http_response&)>&& handler);
+
+    /// @brief Add a route to the server.
+    /// @param path The HTTP path to match in order to call the handler.
+    /// @param methods The HTTP methods to match in order to call the handler.
+    /// @param handler The function to call when the route is requested.
+    /// The second parameter of the handler represents the response to send
+    /// to the client.
+    /// @return A reference to the created route.
+    route& add_route(std::string&& path,
+                     std::vector<pine::http_method>&& methods,
+                     std::function<void(const http_request&,
+                                        http_response&)>&& handler);
 
     static_route& add_static_route(std::string&& path,
-                            std::filesystem::path&& location);
+                                   std::filesystem::path&& location);
 
     const std::shared_ptr<route_base> get_route(const std::string& path) const;
 

--- a/server/include/server.h
+++ b/server/include/server.h
@@ -55,7 +55,7 @@ namespace pine
     route& add_route(std::string&& path,
                      std::function<void(const http_request&,
                                         http_response&)>&& handler);
-    
+
     /// @brief Add a route to the server.
     /// @param path The HTTP path to match in order to call the handler.
     /// @param method The HTTP method to match in order to call the handler.
@@ -80,10 +80,20 @@ namespace pine
                      std::function<void(const http_request&,
                                         http_response&)>&& handler);
 
+    /// @brief Add a static route to the server. The route will serve files from
+    /// the specified directory, or the specified file.
+    /// @param path The path to match in order to serve files from the location.
+    /// @param location The location to serve files from.
+    /// @return 
     static_route& add_static_route(std::string&& path,
                                    std::filesystem::path&& location);
 
-    const std::shared_ptr<route_base> get_route(const std::string& path) const;
+    /// @brief Get a route by path and method.
+    /// @return If the route was found, a shared pointer to the route.
+    /// If the route was not found, an error code.
+    std::expected<const std::shared_ptr<route_base>, error>
+      get_route(const std::string& path,
+                http_method methods) const;
 
   private:
     /// @brief Accept clients.

--- a/server/include/server_connection.h
+++ b/server/include/server_connection.h
@@ -21,6 +21,8 @@ namespace pine
     /// @brief Construct a server connection with the given socket and server.
     explicit server_connection(SOCKET socket, pine::server& server);
 
+    async_operation<void> handle_request(const http_request& request);
+
     /// @brief Receive an HTTP request.
     /// @return An asynchronous task completed when the request has been received.
     async_operation<http_request> receive_request() const;

--- a/server/include/static_route.h
+++ b/server/include/static_route.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <filesystem>
 #include <http_request.h>
 #include <http_response.h>
 #include <route_base.h>
 #include <string>
-#include <filesystem>
+#include <type_traits>
 
 namespace pine
 {
@@ -27,13 +28,11 @@ namespace pine
     /// @param path The path to match in order to serve files from the location.
     /// @param location The location to serve files from.
     static_route(std::string&& path, std::filesystem::path&& location)
-      : path_(std::move(path))
+      : route_base(std::forward<std::string>(path))
       , location_(std::move(location))
     {}
 
     ~static_route() = default;
-
-    const std::string& path() const override { return path_; }
 
     /// @brief Execute the route. This function will attempt to serve the file
     /// from the location specified when the route was created and the path of
@@ -57,7 +56,6 @@ namespace pine
     bool matches(const std::string& path) const override;
 
   private:
-    std::string path_;
     std::filesystem::path location_;
   };
 }

--- a/server/src/route.cpp
+++ b/server/src/route.cpp
@@ -1,9 +1,12 @@
 #include <functional>
+#include <http.h>
+#include <route_base.h>
 #include <string>
 #include <type_traits>
-#include "http_request.h"
-#include "http_response.h"
-#include "route.h"
+#include <vector>
+#include <http_request.h>
+#include <http_response.h>
+#include <route.h>
 
 namespace pine
 {
@@ -11,8 +14,9 @@ namespace pine
                              std::function<void(const http_request&,
                                                 http_response&)>&&
                              handler)
-    : path_(std::move(path))
-    , handler_(std::move(handler))
+    : route_base(std::forward<std::string>(path))
+    , handler_(std::forward< std::function<void(const http_request&,
+                                                http_response&)>>(handler))
   {}
 
   void route::execute(const http_request& request,

--- a/server/src/route.cpp
+++ b/server/src/route.cpp
@@ -11,13 +11,37 @@
 namespace pine
 {
   route::route(std::string&& path,
-                             std::function<void(const http_request&,
-                                                http_response&)>&&
-                             handler)
+               std::function<void(const http_request&,
+                                  http_response&)>&&
+               handler)
     : route_base(std::forward<std::string>(path))
     , handler_(std::forward< std::function<void(const http_request&,
                                                 http_response&)>>(handler))
   {}
+
+  route::route(std::string&& path,
+               http_method method,
+               std::function<void(const http_request&,
+                                  http_response&)>&&
+               handler)
+    : route_base(std::forward < std::string>(path))
+    , handler_(std::forward < std::function<void(const http_request&,
+                                                 http_response&)>>(handler))
+  {
+    set_method(method);
+  }
+
+  route::route(std::string&& path,
+               std::vector<http_method>&& methods,
+               std::function<void(const http_request&,
+                                  http_response&)>&&
+               handler)
+    : route_base(std::forward<std::string>(path))
+    , handler_(std::forward < std::function<void(const http_request&,
+                                                 http_response&)>>(handler))
+  {
+    set_methods(std::forward<std::vector<http_method>>(methods));
+  }
 
   void route::execute(const http_request& request,
                       http_response& response)

--- a/server/src/server.cpp
+++ b/server/src/server.cpp
@@ -1,9 +1,10 @@
-#include "server.h"
 #include <coroutine.h>
 #include <cstdint>
 #include <error.h>
 #include <expected.h>
+#include <filesystem>
 #include <functional>
+#include <http.h>
 #include <http_request.h>
 #include <http_response.h>
 #include <memory>
@@ -14,6 +15,7 @@
 #include <static_route.h>
 #include <string>
 #include <type_traits>
+#include <vector>
 #include <wsa.h>
 
 namespace pine
@@ -141,11 +143,38 @@ namespace pine
   }
 
   route& server::add_route(std::string&& path,
-                                  std::function<void(const http_request&,
-                                                     http_response&)>&& handler)
+                           std::function<void(const http_request&,
+                                              http_response&)>&& handler)
   {
-    auto new_route = std::make_shared<route>(std::move(path),
-                                                std::move(handler));
+    return add_route(std::forward<std::string>(path),
+                     std::vector{ http_method::get },
+                     std::forward<std::function<void(const http_request&,
+                                                     http_response&)>>(handler));
+  }
+
+  route& server::add_route(std::string&& path,
+                           pine::http_method method,
+                           std::function<void(const http_request&,
+                                              http_response&)>&& handler)
+  {
+    return add_route(std::forward<std::string>(path),
+                     std::vector{ method },
+                     std::forward<std::function<void(const http_request&,
+                                                     http_response&)>>(handler));
+  }
+
+  route& server::add_route(std::string&& path,
+                           std::vector<pine::http_method>&& methods,
+                           std::function<void(const http_request&,
+                                              http_response&)>&& handler)
+  {
+    auto new_route =
+      std::make_shared<route>(std::forward<std::string>(path),
+                              std::forward<std::vector<
+                              pine::http_method>>(methods),
+                              std::forward<
+                              std::function<void(const http_request&,
+                                                 http_response&)>>(handler));
     this->routes.push_back(new_route);
     return *new_route;
   }

--- a/shared/include/error.h
+++ b/shared/include/error.h
@@ -13,6 +13,8 @@ namespace pine
     parse_error_headers,
     parse_error_body,
     parse_error_status,
+    route_not_found,
+    method_not_allowed,
     client_not_found,
     connection_closed,
   #ifdef _WIN32

--- a/shared/include/http.h
+++ b/shared/include/http.h
@@ -40,6 +40,7 @@ namespace pine
     { http_status::ok, "OK" },
     { http_status::bad_request, "Bad Request" },
     { http_status::not_found, "Not Found" },
+    { http_status::method_not_allowed, "Method Not Allowed" },
     { http_status::internal_server_error, "Internal Server Error" },
   };
 

--- a/shared/include/http.h
+++ b/shared/include/http.h
@@ -30,6 +30,7 @@ namespace pine
     ok = 200, /// The OK status code.
     bad_request = 400, /// The Bad Request status code.
     not_found = 404, /// The Not Found status code.
+    method_not_allowed = 405, /// The Method Not Allowed status code.
     internal_server_error = 500, /// The Internal Server Error status code.
   };
 


### PR DESCRIPTION
#### PR Classification
New feature: Added support for handling multiple HTTP methods in route handling.

#### PR Summary
Introduced the ability to handle multiple HTTP methods for a single route.
- Updated `route` class to accept multiple HTTP methods.
- Enhanced `server` class to manage routes with multiple methods and retrieve them based on path and method.
- Added `handle_request` function in `server_connection` to process requests by path and method.
- Improved error handling to return specific HTTP status codes for "Not Found" and "Method Not Allowed".
- Updated documentation comments to reflect changes in route handling.

closes: #19 