### PR TITLE
Introduce a new class for path validation and encapsulation

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(server
     "include/server_connection.h"
     "include/route.h" 
     "include/route_base.h"
+    "include/route_path.h"
     "include/static_route.h"
 )
 

--- a/server/include/route.h
+++ b/server/include/route.h
@@ -15,17 +15,18 @@ namespace pine
   {
   public:
     route() = default;
-    route(std::string&& path,
+    route(route_path path,
           std::function<void(const http_request&,
                              http_response&)>&&
           handler);
-    route(std::string&& path,
+
+    route(route_path path,
           http_method method,
           std::function<void(const http_request&,
                              http_response&)>&&
           handler);
 
-    route(std::string&& path,
+    route(route_path path,
           std::vector<http_method>&& methods,
           std::function<void(const http_request&,
                              http_response&)>&&

--- a/server/include/route_base.h
+++ b/server/include/route_base.h
@@ -3,6 +3,8 @@
 #include <http.h>
 #include <http_request.h>
 #include <http_response.h>
+#include <route_path.h>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -13,9 +15,10 @@ namespace pine
   {
   public:
     route_base() = delete;
-    constexpr route_base(std::string&& path)
-      : path_(std::forward<std::string>(path))
-    {}
+    constexpr route_base(route_path path)
+    {
+      path_ = std::string(path.get());
+    }
 
     virtual ~route_base() = default;
     virtual void execute(const http_request& request,

--- a/server/include/route_path.h
+++ b/server/include/route_path.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <format>
+#include <string_view>
+
+namespace pine
+{
+  class route_path
+  {
+  public:
+    template <typename T>
+    consteval route_path(const T& path)
+      : path_{ path }
+    {
+      if (!validate_path(path_))
+      {
+        throw std::format_error("Invalid path");
+      }
+    }
+
+    /// @brief Validates a path. A path must start with a forward slash and may
+/// contain only the following characters:
+/// 
+/// - Lowercase letters (a-z)
+/// 
+/// - Uppercase letters (A-Z)
+/// 
+/// - Digits (0-9)
+/// 
+/// - Following special characters: - _ . ~ ! $ & ' ( ) * + , ; = : @ /
+/// 
+/// @param path The path to validate.
+/// @return True if the path is valid; false otherwise.
+    static constexpr bool validate_path(std::string_view path)
+    {
+      if (path.empty())
+        return false;
+
+      if (path[0] != '/')
+        return false;
+
+      char prev = path[0];
+      for (size_t i = 1; i < path.size(); ++i)
+      {
+        if ((path[i] < 'a' || path[i] > 'z') &&
+            (path[i] < 'A' || path[i] > 'Z') &&
+            (path[i] < '0' || path[i] > '9') &&
+            path[i] != '-' &&
+            path[i] != '_' &&
+            path[i] != '.' &&
+            path[i] != '~' &&
+            path[i] != '!' &&
+            path[i] != '$' &&
+            path[i] != '&' &&
+            path[i] != '\'' &&
+            path[i] != '(' &&
+            path[i] != ')' &&
+            path[i] != '*' &&
+            path[i] != '+' &&
+            path[i] != ',' &&
+            path[i] != ';' &&
+            path[i] != '=' &&
+            path[i] != ':' &&
+            path[i] != '@' &&
+            path[i] != '/')
+          return false;
+      }
+
+      return true;
+    }
+
+    /// @brief Get the path as a string view.
+    constexpr auto get() const noexcept
+    {
+      return path_;
+    }
+
+  private:
+    std::string_view path_;
+  };
+}

--- a/server/include/server.h
+++ b/server/include/server.h
@@ -52,7 +52,7 @@ namespace pine
     /// The second parameter of the handler represents the response to send
     /// to the client.
     /// @return A reference to the created route.
-    route& add_route(std::string&& path,
+    route& add_route(route_path path,
                      std::function<void(const http_request&,
                                         http_response&)>&& handler);
 
@@ -63,7 +63,7 @@ namespace pine
     /// The second parameter of the handler represents the response to send
     /// to the client.
     /// @return A reference to the created route.
-    route& add_route(std::string&& path,
+    route& add_route(route_path path,
                      pine::http_method method,
                      std::function<void(const http_request&,
                                         http_response&)>&& handler);
@@ -75,7 +75,7 @@ namespace pine
     /// The second parameter of the handler represents the response to send
     /// to the client.
     /// @return A reference to the created route.
-    route& add_route(std::string&& path,
+    route& add_route(route_path path,
                      std::vector<pine::http_method>&& methods,
                      std::function<void(const http_request&,
                                         http_response&)>&& handler);
@@ -85,7 +85,7 @@ namespace pine
     /// @param path The path to match in order to serve files from the location.
     /// @param location The location to serve files from.
     /// @return 
-    static_route& add_static_route(std::string&& path,
+    static_route& add_static_route(route_path path,
                                    std::filesystem::path&& location);
 
     /// @brief Get a route by path and method.

--- a/server/include/static_route.h
+++ b/server/include/static_route.h
@@ -27,8 +27,8 @@ namespace pine
     /// - If the location is a file, the route will serve that file.
     /// @param path The path to match in order to serve files from the location.
     /// @param location The location to serve files from.
-    static_route(std::string&& path, std::filesystem::path&& location)
-      : route_base(std::forward<std::string>(path))
+    static_route(route_path path, std::filesystem::path&& location)
+      : route_base(path)
       , location_(std::move(location))
     {}
 

--- a/server/src/route.cpp
+++ b/server/src/route.cpp
@@ -1,42 +1,42 @@
 #include <functional>
 #include <http.h>
-#include <route_base.h>
-#include <string>
-#include <type_traits>
-#include <vector>
 #include <http_request.h>
 #include <http_response.h>
 #include <route.h>
+#include <route_base.h>
+#include <type_traits>
+#include <vector>
 
 namespace pine
 {
-  route::route(std::string&& path,
+  route::route(route_path path,
                std::function<void(const http_request&,
                                   http_response&)>&&
                handler)
-    : route_base(std::forward<std::string>(path))
+    : route_base(path)
     , handler_(std::forward< std::function<void(const http_request&,
                                                 http_response&)>>(handler))
+
   {}
 
-  route::route(std::string&& path,
+  route::route(route_path path,
                http_method method,
                std::function<void(const http_request&,
                                   http_response&)>&&
                handler)
-    : route_base(std::forward < std::string>(path))
+    : route_base(path)
     , handler_(std::forward < std::function<void(const http_request&,
                                                  http_response&)>>(handler))
   {
     set_method(method);
   }
 
-  route::route(std::string&& path,
+  route::route(route_path path,
                std::vector<http_method>&& methods,
                std::function<void(const http_request&,
                                   http_response&)>&&
                handler)
-    : route_base(std::forward<std::string>(path))
+    : route_base(path)
     , handler_(std::forward < std::function<void(const http_request&,
                                                  http_response&)>>(handler))
   {

--- a/server/src/server.cpp
+++ b/server/src/server.cpp
@@ -142,34 +142,34 @@ namespace pine
     co_return{};
   }
 
-  route& server::add_route(std::string&& path,
+  route& server::add_route(route_path path,
                            std::function<void(const http_request&,
                                               http_response&)>&& handler)
   {
-    return add_route(std::forward<std::string>(path),
+    return add_route(path,
                      std::vector{ http_method::get },
                      std::forward<std::function<void(const http_request&,
                                                      http_response&)>>(handler));
   }
 
-  route& server::add_route(std::string&& path,
+  route& server::add_route(route_path path,
                            pine::http_method method,
                            std::function<void(const http_request&,
                                               http_response&)>&& handler)
   {
-    return add_route(std::forward<std::string>(path),
+    return add_route(path,
                      std::vector{ method },
                      std::forward<std::function<void(const http_request&,
                                                      http_response&)>>(handler));
   }
 
-  route& server::add_route(std::string&& path,
+  route& server::add_route(route_path path,
                            std::vector<pine::http_method>&& methods,
                            std::function<void(const http_request&,
                                               http_response&)>&& handler)
   {
     auto new_route =
-      std::make_shared<route>(std::forward<std::string>(path),
+      std::make_shared<route>(path,
                               std::forward<std::vector<
                               pine::http_method>>(methods),
                               std::forward<
@@ -179,9 +179,9 @@ namespace pine
     return *new_route;
   }
 
-  static_route& server::add_static_route(std::string&& path, std::filesystem::path&& location)
+  static_route& server::add_static_route(route_path path, std::filesystem::path&& location)
   {
-    auto new_route = std::make_shared<static_route>(std::move(path),
+    auto new_route = std::make_shared<static_route>(path,
                                                     std::move(location));
     this->routes.push_back(new_route);
     return *new_route;


### PR DESCRIPTION
#### PR Classification
API change to introduce a new `route_path` class for path validation and encapsulation.

#### PR Summary
Replaced `std::string` path parameters with the new `route_path` class across various components to ensure path validation.
- `CMakeLists.txt`: Included `route_path.h` in `target_sources` for `server`.
- `route.h` and `route.cpp`: Updated `route` class constructors to use `route_path`.
- `route_base.h`: Modified `route_base` constructor to use `route_path` with validation.
- `server.h` and `server.cpp`: Updated `server` class methods to use `route_path`.
- `static_route.h`: Updated `static_route` constructor to use `route_path`.

closes: #22 